### PR TITLE
feat: adds v2 SDK compatible version of component

### DIFF
--- a/components/web/Download/component-sdk-v2
+++ b/components/web/Download/component-sdk-v2
@@ -1,0 +1,25 @@
+name: Download data (KFP SDK v2)
+description: Downloads data from the specified URL. (Updated for KFP SDK v2.)
+inputs:
+- {name: Url, type: String}
+- {name: curl options, type: String, default: '--location', description: 'Additional options given to the curl bprogram. See https://curl.haxx.se/docs/manpage.html'}
+outputs:
+- {name: Data, type: Artifact}
+metadata:
+  annotations:
+    author: Alexey Volkov <alexey.volkov@ark-kun.com>
+implementation:
+  container:
+    image: curlimages/curl
+    command:
+    - sh
+    - -exc
+    - |
+      url="$0"
+      output_path="$1"
+      curl_options="$2"
+      mkdir -p "$(dirname "$output_path")"
+      curl --get "$url" --output "$output_path" $curl_options
+    - inputValue: Url
+    - outputPath: Data
+    - inputValue: curl options


### PR DESCRIPTION
Adds KFP v2 SDK compatible version of the web download component. This component is used in an example in the docs.


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
